### PR TITLE
Sort includes

### DIFF
--- a/src/colstr.c
+++ b/src/colstr.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/colstr.h>
+#include "ofc/colstr.h"
 
 
 struct ofc_colstr_s

--- a/src/colstr.c
+++ b/src/colstr.c
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-#include <ofc/colstr.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <ofc/colstr.h>
 
 
 struct ofc_colstr_s

--- a/src/fctype.c
+++ b/src/fctype.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/fctype.h>
+#include "ofc/fctype.h"
 
 bool ofc_is_vspace(char c)
 {

--- a/src/file.c
+++ b/src/file.c
@@ -21,8 +21,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <ofc/fctype.h>
-#include <ofc/file.h>
+#include "ofc/fctype.h"
+#include "ofc/file.h"
 
 
 struct ofc_file_s

--- a/src/file.c
+++ b/src/file.c
@@ -13,15 +13,16 @@
  * limitations under the License.
  */
 
-#include <ofc/file.h>
-#include <ofc/fctype.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdint.h>
-#include <unistd.h>
 #include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
+#include <unistd.h>
+
+#include <ofc/fctype.h>
+#include <ofc/file.h>
 
 
 struct ofc_file_s

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/hashmap.h>
+#include "ofc/hashmap.h"
 
 typedef struct ofc_hashmap__entry_s ofc_hashmap__entry_t;
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/hashmap.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <ofc/hashmap.h>
 
 typedef struct ofc_hashmap__entry_s ofc_hashmap__entry_t;
 

--- a/src/label_table.c
+++ b/src/label_table.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/label_table.h>
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
+
+#include <ofc/label_table.h>
 
 typedef struct label_s label_t;
 

--- a/src/label_table.c
+++ b/src/label_table.c
@@ -16,7 +16,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <ofc/label_table.h>
+#include "ofc/label_table.h"
 
 typedef struct label_s label_t;
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,14 +13,14 @@
  * limitations under the License.
  */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
 #include <ofc/file.h>
-#include <ofc/prep.h>
 #include <ofc/parse/file.h>
+#include <ofc/prep.h>
 #include <ofc/sema.h>
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -18,10 +18,10 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <ofc/file.h>
-#include <ofc/parse/file.h>
-#include <ofc/prep.h>
-#include <ofc/sema.h>
+#include "ofc/file.h"
+#include "ofc/parse/file.h"
+#include "ofc/prep.h"
+#include "ofc/sema.h"
 
 
 void print_usage(const char* name)

--- a/src/parse/array.c
+++ b/src/parse/array.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static ofc_parse_array_range_t* ofc_parse_array__range(

--- a/src/parse/assign.c
+++ b/src/parse/assign.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_assign_t* ofc_parse_assign(

--- a/src/parse/call_arg.c
+++ b/src/parse/call_arg.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static ofc_parse_call_arg_t* ofc_parse__call_arg(

--- a/src/parse/common.c
+++ b/src/parse/common.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_common_group_t* ofc_parse_common_group(

--- a/src/parse/data.c
+++ b/src/parse/data.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static ofc_parse_clist_entry_t* ofc_parse_clist_entry(

--- a/src/parse/debug.c
+++ b/src/parse/debug.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/parse/debug.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+#include <ofc/parse/debug.h>
 
 typedef struct
 {

--- a/src/parse/debug.c
+++ b/src/parse/debug.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <ofc/parse/debug.h>
+#include "ofc/parse/debug.h"
 
 typedef struct
 {

--- a/src/parse/decl.c
+++ b/src/parse/decl.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_decl_t* ofc_parse_decl(

--- a/src/parse/define_file_arg.c
+++ b/src/parse/define_file_arg.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_define_file_arg_t* ofc_parse_define_file_arg(

--- a/src/parse/expr.c
+++ b/src/parse/expr.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 

--- a/src/parse/file.c
+++ b/src/parse/file.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_stmt_list_t* ofc_parse_file(const ofc_sparse_t* src)

--- a/src/parse/format.c
+++ b/src/parse/format.c
@@ -17,7 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 typedef struct

--- a/src/parse/format.c
+++ b/src/parse/format.c
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
+
+#include <ofc/parse.h>
 
 
 typedef struct

--- a/src/parse/implicit.c
+++ b/src/parse/implicit.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_implicit__mask(

--- a/src/parse/implicit_do.c
+++ b/src/parse/implicit_do.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_implicit_do_t* ofc_parse_implicit_do(

--- a/src/parse/keyword.c
+++ b/src/parse/keyword.c
@@ -16,7 +16,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 

--- a/src/parse/keyword.c
+++ b/src/parse/keyword.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
-#include <string.h>
 #include <ctype.h>
+#include <string.h>
+
+#include <ofc/parse.h>
 
 
 

--- a/src/parse/lhs.c
+++ b/src/parse/lhs.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static void ofc_parse_lhs__cleanup(

--- a/src/parse/list.c
+++ b/src/parse/list.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_list__seperator_optional(

--- a/src/parse/literal.c
+++ b/src/parse/literal.c
@@ -17,7 +17,7 @@
 #include <math.h>
 #include <string.h>
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static bool is_base_digit(

--- a/src/parse/literal.c
+++ b/src/parse/literal.c
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
-#include <string.h>
 #include <ctype.h>
 #include <math.h>
+#include <string.h>
+
+#include <ofc/parse.h>
 
 
 static bool is_base_digit(

--- a/src/parse/operator.c
+++ b/src/parse/operator.c
@@ -15,7 +15,7 @@
 
 #include <string.h>
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 static const char* ofc_parse_operator__name[] =
 {

--- a/src/parse/operator.c
+++ b/src/parse/operator.c
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
 #include <string.h>
+
+#include <ofc/parse.h>
 
 static const char* ofc_parse_operator__name[] =
 {

--- a/src/parse/pointer.c
+++ b/src/parse/pointer.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static ofc_parse_pointer_t* ofc_parse_pointer(

--- a/src/parse/record.c
+++ b/src/parse/record.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static ofc_parse_record_t* ofc_parse_record(

--- a/src/parse/save.c
+++ b/src/parse/save.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 ofc_parse_save_t* ofc_parse_save(

--- a/src/parse/star_len.c
+++ b/src/parse/star_len.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_star_len(

--- a/src/parse/stmt.c
+++ b/src/parse/stmt.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_include(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/assign.c
+++ b/src/parse/stmt/assign.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_assign(

--- a/src/parse/stmt/call_entry.c
+++ b/src/parse/stmt/call_entry.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_call(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/common.c
+++ b/src/parse/stmt/common.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_stmt__common_namelist(

--- a/src/parse/stmt/continue.c
+++ b/src/parse/stmt/continue.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_continue(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/cycle.c
+++ b/src/parse/stmt/cycle.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_cycle(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/data.c
+++ b/src/parse/stmt/data.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 

--- a/src/parse/stmt/decl.c
+++ b/src/parse/stmt/decl.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_decl(

--- a/src/parse/stmt/decl_attr.c
+++ b/src/parse/stmt/decl_attr.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_stmt__decl_attr(

--- a/src/parse/stmt/dimension.c
+++ b/src/parse/stmt/dimension.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_stmt__dimension_virtual(

--- a/src/parse/stmt/do.c
+++ b/src/parse/stmt/do.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt__do_while_block(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/equivalence.c
+++ b/src/parse/stmt/equivalence.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_equivalence(

--- a/src/parse/stmt/exit.c
+++ b/src/parse/stmt/exit.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_exit(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/format.c
+++ b/src/parse/stmt/format.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 unsigned ofc_parse_stmt_format(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/go_to.c
+++ b/src/parse/stmt/go_to.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 static unsigned ofc_parse_stmt_go_to_unconditional(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/if.c
+++ b/src/parse/stmt/if.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 static unsigned ofc_parse_stmt_if__computed(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/implicit.c
+++ b/src/parse/stmt/implicit.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 

--- a/src/parse/stmt/include.c
+++ b/src/parse/stmt/include.c
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-#include <ofc/parse/file.h>
-#include <ofc/file.h>
-#include <ofc/prep.h>
 #include <string.h>
+
+#include <ofc/file.h>
+#include <ofc/parse/file.h>
+#include <ofc/prep.h>
 
 
 unsigned ofc_parse_stmt_include(

--- a/src/parse/stmt/include.c
+++ b/src/parse/stmt/include.c
@@ -15,9 +15,9 @@
 
 #include <string.h>
 
-#include <ofc/file.h>
-#include <ofc/parse/file.h>
-#include <ofc/prep.h>
+#include "ofc/file.h"
+#include "ofc/parse/file.h"
+#include "ofc/prep.h"
 
 
 unsigned ofc_parse_stmt_include(

--- a/src/parse/stmt/io.c
+++ b/src/parse/stmt/io.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 

--- a/src/parse/stmt/parameter.c
+++ b/src/parse/stmt/parameter.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_parameter(

--- a/src/parse/stmt/pointer.c
+++ b/src/parse/stmt/pointer.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_pointer(

--- a/src/parse/stmt/program.c
+++ b/src/parse/stmt/program.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_program__body(

--- a/src/parse/stmt/return.c
+++ b/src/parse/stmt/return.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 static unsigned ofc_parse_stmt__return(
 	const ofc_sparse_t* src, const char* ptr,

--- a/src/parse/stmt/save.c
+++ b/src/parse/stmt/save.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 unsigned ofc_parse_stmt_save(

--- a/src/parse/stmt/structure.c
+++ b/src/parse/stmt/structure.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 
 static unsigned ofc_parse_stmt__structure(

--- a/src/parse/type.c
+++ b/src/parse/type.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/parse.h>
 #include <ctype.h>
 #include <string.h>
+
+#include <ofc/parse.h>
 
 static const char* ofc_parse_type__name[] =
 {

--- a/src/parse/type.c
+++ b/src/parse/type.c
@@ -16,7 +16,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#include <ofc/parse.h>
+#include "ofc/parse.h"
 
 static const char* ofc_parse_type__name[] =
 {

--- a/src/prep/condense.c
+++ b/src/prep/condense.c
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-#include <ofc/prep.h>
-#include <ofc/fctype.h>
 #include <stdlib.h>
+
+#include <ofc/fctype.h>
+#include <ofc/prep.h>
 
 
 ofc_sparse_t* ofc_prep_condense(ofc_sparse_t* unformat)

--- a/src/prep/condense.c
+++ b/src/prep/condense.c
@@ -15,8 +15,8 @@
 
 #include <stdlib.h>
 
-#include <ofc/fctype.h>
-#include <ofc/prep.h>
+#include "ofc/fctype.h"
+#include "ofc/prep.h"
 
 
 ofc_sparse_t* ofc_prep_condense(ofc_sparse_t* unformat)

--- a/src/prep/prep.c
+++ b/src/prep/prep.c
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-#include <ofc/prep.h>
 #include <stdlib.h>
+
+#include <ofc/prep.h>
 
 
 ofc_sparse_t* ofc_prep(ofc_file_t* file)

--- a/src/prep/prep.c
+++ b/src/prep/prep.c
@@ -15,7 +15,7 @@
 
 #include <stdlib.h>
 
-#include <ofc/prep.h>
+#include "ofc/prep.h"
 
 
 ofc_sparse_t* ofc_prep(ofc_file_t* file)

--- a/src/prep/unformat.c
+++ b/src/prep/unformat.c
@@ -17,8 +17,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/fctype.h>
-#include <ofc/prep.h>
+#include "ofc/fctype.h"
+#include "ofc/prep.h"
 
 
 static unsigned ofc_prep_unformat__blank_or_comment(

--- a/src/prep/unformat.c
+++ b/src/prep/unformat.c
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-#include <ofc/prep.h>
-#include <ofc/fctype.h>
-
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+#include <ofc/fctype.h>
+#include <ofc/prep.h>
 
 
 static unsigned ofc_prep_unformat__blank_or_comment(

--- a/src/sema/arg.c
+++ b/src/sema/arg.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 static ofc_sema_arg_list_t* ofc_sema_arg_list__create(unsigned count)
 {

--- a/src/sema/array.c
+++ b/src/sema/array.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 

--- a/src/sema/common.c
+++ b/src/sema/common.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_common_t* ofc_sema_common_create(

--- a/src/sema/decl.c
+++ b/src/sema/decl.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_decl_t* ofc_sema_decl_create(

--- a/src/sema/equiv.c
+++ b/src/sema/equiv.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 static uint8_t ofc_sema_equiv__hash(const ofc_sema_decl_t* decl)

--- a/src/sema/expr.c
+++ b/src/sema/expr.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 const ofc_sema_typeval_t* ofc_sema_expr_constant(

--- a/src/sema/format.c
+++ b/src/sema/format.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 static bool ofc_sema__type_rule[][9] =
 {

--- a/src/sema/implicit.c
+++ b/src/sema/implicit.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 struct ofc_sema_implicit_s
 {

--- a/src/sema/intrinsic.c
+++ b/src/sema/intrinsic.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 typedef enum
 {

--- a/src/sema/io.c
+++ b/src/sema/io.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 /* Compare type to descriptor type at
  * offset position in format_list

--- a/src/sema/label.c
+++ b/src/sema/label.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 static void ofc_sema_label__delete(
 	ofc_sema_label_t* label)

--- a/src/sema/lhs.c
+++ b/src/sema/lhs.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 static ofc_sema_lhs_t* ofc_sema_lhs_index(

--- a/src/sema/parameter.c
+++ b/src/sema/parameter.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_hashmap_t* ofc_sema_parameter_map_create(

--- a/src/sema/scope.c
+++ b/src/sema/scope.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 void ofc_sema_scope_delete(

--- a/src/sema/spec.c
+++ b/src/sema/spec.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 

--- a/src/sema/stmt.c
+++ b/src/sema/stmt.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 bool ofc_sema_stmt_assignment_print(ofc_colstr_t* cs,
 	const ofc_sema_stmt_t* stmt);

--- a/src/sema/stmt/assign.c
+++ b/src/sema/stmt/assign.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_stmt_t* ofc_sema_stmt_assign(

--- a/src/sema/stmt/assignment.c
+++ b/src/sema/stmt/assignment.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_is_stmt_func(

--- a/src/sema/stmt/call.c
+++ b/src/sema/stmt/call.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_stmt_t* ofc_sema_stmt_call(

--- a/src/sema/stmt/close.c
+++ b/src/sema/stmt/close.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 void ofc_sema_stmt_io_close__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/stmt/common.c
+++ b/src/sema/stmt/common.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_common(

--- a/src/sema/stmt/data.c
+++ b/src/sema/stmt/data.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 static bool ofc_sema_stmt__data(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/decl_attr.c
+++ b/src/sema/stmt/decl_attr.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_decl_attr(

--- a/src/sema/stmt/dimension.c
+++ b/src/sema/stmt/dimension.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_dimension(

--- a/src/sema/stmt/do.c
+++ b/src/sema/stmt/do.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 static bool ofc_sema_stmt__loop_control(

--- a/src/sema/stmt/entry.c
+++ b/src/sema/stmt/entry.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_stmt_t* ofc_sema_stmt_entry(

--- a/src/sema/stmt/equivalence.c
+++ b/src/sema/stmt/equivalence.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_equivalence(

--- a/src/sema/stmt/go_to.c
+++ b/src/sema/stmt/go_to.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 static ofc_sema_stmt_t* ofc_sema_stmt_go_to__assigned(

--- a/src/sema/stmt/if.c
+++ b/src/sema/stmt/if.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 ofc_sema_stmt_t* ofc_sema_stmt_if__computed(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/inquire.c
+++ b/src/sema/stmt/inquire.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 void ofc_sema_stmt_io_inquire__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/stmt/io_position.c
+++ b/src/sema/stmt/io_position.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 ofc_sema_stmt_t* ofc_sema_stmt_io_position(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/open.c
+++ b/src/sema/stmt/open.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 void ofc_sema_stmt_io_open__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/stmt/print.c
+++ b/src/sema/stmt/print.c
@@ -15,7 +15,7 @@
 
 #include <math.h>
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 ofc_sema_stmt_t* ofc_sema_stmt_io_print(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/print.c
+++ b/src/sema/stmt/print.c
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
 #include <math.h>
+
+#include <ofc/sema.h>
 
 ofc_sema_stmt_t* ofc_sema_stmt_io_print(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/read.c
+++ b/src/sema/stmt/read.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 void ofc_sema_stmt_io_read__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/stmt/return.c
+++ b/src/sema/stmt/return.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 ofc_sema_stmt_t* ofc_sema_stmt_return(

--- a/src/sema/stmt/save.c
+++ b/src/sema/stmt/save.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 
 bool ofc_sema_stmt_save(

--- a/src/sema/stmt/stop_pause.c
+++ b/src/sema/stmt/stop_pause.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 ofc_sema_stmt_t* ofc_sema_stmt_stop_pause(
 	ofc_sema_scope_t* scope,

--- a/src/sema/stmt/write.c
+++ b/src/sema/stmt/write.c
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
 #include <math.h>
+
+#include <ofc/sema.h>
 
 void ofc_sema_stmt_io_write__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/stmt/write.c
+++ b/src/sema/stmt/write.c
@@ -15,7 +15,7 @@
 
 #include <math.h>
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 void ofc_sema_stmt_io_write__cleanup(
 	ofc_sema_stmt_t s)

--- a/src/sema/structure.c
+++ b/src/sema/structure.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include <ofc/hashmap.h>
-#include <ofc/sema.h>
+#include "ofc/hashmap.h"
+#include "ofc/sema.h"
 
 
 void ofc_sema_structure__delete_locked(ofc_sema_structure_t* structure)

--- a/src/sema/structure.c
+++ b/src/sema/structure.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
 #include <ofc/hashmap.h>
+#include <ofc/sema.h>
 
 
 void ofc_sema_structure__delete_locked(ofc_sema_structure_t* structure)

--- a/src/sema/type.c
+++ b/src/sema/type.c
@@ -15,7 +15,7 @@
 
 #include <string.h>
 
-#include <ofc/sema.h>
+#include "ofc/sema.h"
 
 static ofc_hashmap_t* ofc_sema_type__map = NULL;
 

--- a/src/sema/type.c
+++ b/src/sema/type.c
@@ -13,8 +13,9 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
 #include <string.h>
+
+#include <ofc/sema.h>
 
 static ofc_hashmap_t* ofc_sema_type__map = NULL;
 

--- a/src/sema/typeval.c
+++ b/src/sema/typeval.c
@@ -20,8 +20,8 @@
 #undef complex
 #endif
 
-#include <ofc/noopt.h>
-#include <ofc/sema.h>
+#include "ofc/noopt.h"
+#include "ofc/sema.h"
 
 
 /* TODO - Remove NO_OPT, once we find a better workaround

--- a/src/sema/typeval.c
+++ b/src/sema/typeval.c
@@ -13,15 +13,16 @@
  * limitations under the License.
  */
 
-#include <ofc/sema.h>
 #include <math.h>
 #include <tgmath.h>
-#include <ofc/noopt.h>
-
 #ifdef complex
 /* Remove macro from complex.h */
 #undef complex
 #endif
+
+#include <ofc/noopt.h>
+#include <ofc/sema.h>
+
 
 /* TODO - Remove NO_OPT, once we find a better workaround
           for the compiler error. */

--- a/src/sparse.c
+++ b/src/sparse.c
@@ -13,11 +13,12 @@
  * limitations under the License.
  */
 
-#include <ofc/sparse.h>
-#include <ofc/fctype.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
+
+#include <ofc/fctype.h>
+#include <ofc/sparse.h>
 
 
 typedef struct

--- a/src/sparse.c
+++ b/src/sparse.c
@@ -17,8 +17,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/fctype.h>
-#include <ofc/sparse.h>
+#include "ofc/fctype.h"
+#include "ofc/sparse.h"
 
 
 typedef struct

--- a/src/str_ref.c
+++ b/src/str_ref.c
@@ -13,10 +13,11 @@
  * limitations under the License.
  */
 
-#include <ofc/str_ref.h>
-#include <string.h>
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
+
+#include <ofc/str_ref.h>
 
 
 bool ofc_str_ref_empty(const ofc_str_ref_t ref)

--- a/src/str_ref.c
+++ b/src/str_ref.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <ofc/str_ref.h>
+#include "ofc/str_ref.h"
 
 
 bool ofc_str_ref_empty(const ofc_str_ref_t ref)

--- a/src/string.c
+++ b/src/string.c
@@ -13,12 +13,13 @@
  * limitations under the License.
  */
 
-#include <ofc/string.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdio.h>
-#include <stdbool.h>
-#include <stdarg.h>
+
+#include <ofc/string.h>
 
 ofc_string_t* ofc_string_create(const char* base, unsigned size)
 {

--- a/src/string.c
+++ b/src/string.c
@@ -19,7 +19,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <ofc/string.h>
+#include "ofc/string.h"
 
 ofc_string_t* ofc_string_create(const char* base, unsigned size)
 {


### PR DESCRIPTION
The first commit sorts the includes and moves includes of the projects own headers in its own block.
The next patch moves all includes of <ofc/*.h> to "ofc/*.h" 
