### PR TITLE
Fix false warning for intrinsics with arg type double

### DIFF
--- a/src/sema/intrinsic.c
+++ b/src/sema/intrinsic.c
@@ -329,7 +329,7 @@ ofc_sema_expr_list_t* ofc_sema_intrinsic_cast(
 			break;
 
 		case IT_DEF_DOUBLE:
-			stype = ofc_sema_type_real_default();
+			stype = ofc_sema_type_double_default();
 			break;
 
 		case IT_DEF_COMPLEX:


### PR DESCRIPTION
Without this patch I get warnings when calling SNGL
