### PR TITLE
Create BINDIR before install binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ clean:
 	$(DEB) $(DEB_DEBUG)
 
 install: $(FRONTEND)
+	install -d $(BINDIR)
 	install $(FRONTEND) $(BINDIR)
 
 uninstall:


### PR DESCRIPTION
If BINDIR is not present when the binary is installed, the binary
will be BINDIR, i.e. /usr/[local/]bin, instead to be installed in
the BINDIR directory.
