### PR TITLE
Use mktemp instead of tempfile

### DIFF
--- a/refortranizer
+++ b/refortranizer
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-TPROG=$(tempfile)
+TPROG=$(mktemp)
 ./ofc --sema-tree $1 | gfortran -x f77 - -o $TPROG && $TPROG
 rm $TPROG


### PR DESCRIPTION
tempfile is not a package in RHEL systems where mktemp is available
for all linux distributions.