### PR TITLE
fix warnings when building with GCC8 

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -286,6 +286,7 @@ bool ofc_file_get_position(
 			case '\r':
 				/* Support Windows line endings when running on cygwin. */
 				if (file->strz[i + 1] == '\n') i++;
+				__attribute__ ((fallthrough));
 			case '\n':
 				r += 1;
 				c = 0;

--- a/src/sema/typeval.c
+++ b/src/sema/typeval.c
@@ -1116,6 +1116,7 @@ ofc_sema_typeval_t* ofc_sema_typeval_cast(
 	ofc_sema_typeval_t tv;
 	tv.type = type;
 	tv.src  = typeval->src;
+	tv.integer = 0;
 
 	unsigned tsize, csize;
 	if (!ofc_sema_type_base_size(typeval->type, &tsize)
@@ -1158,7 +1159,6 @@ ofc_sema_typeval_t* ofc_sema_typeval_cast(
 		ofc_sparse_ref_warning(typeval->src,
 			"Casting CHARACTER to INTEGER");
 
-		tv.integer = 0;
 		memcpy(&tv.integer, typeval->character, csize);
 		return ofc_sema_typeval__alloc(tv);
 	}


### PR DESCRIPTION
This is a fix for #45 and #43, however, from taking a look at output from Travis CI, it's incompatible with GCC 4.8.